### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,8 @@ jobs:
   #       path: bin/releases
   build-main:
     name: Main Release Assets
+    permissions:
+      contents: write
     # needs:
     #   - build-windows
     #   - build-macos


### PR DESCRIPTION
Potential fix for [https://github.com/checkout-anywhere/git-lfs/security/code-scanning/4](https://github.com/checkout-anywhere/git-lfs/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `Main Release Assets` job. This block should grant the minimal permissions required for the job to function correctly. Based on the steps in the job:
- The `actions/create-release@v1` step requires `contents: write` to create a release.
- The `actions/upload-release-asset@v1` step also requires `contents: write` to upload assets to the release.

We will add the following `permissions` block to the `Main Release Assets` job:
```yaml
permissions:
  contents: write
```

This ensures that the job has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
